### PR TITLE
support new ingress version

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     implementation("org.postgresql:postgresql:42.2.12")
 
-    implementation("io.fabric8:kubernetes-client:5.2.1")
+    implementation("io.fabric8:kubernetes-client:5.12.3")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
 


### PR DESCRIPTION
Hey @danakuban Thanks for providing this awesome plugin.
We migrated our kubernetes cluster to 1.21 and use the new ingress version: networking/v1.
My proposed change queries both version of ingresses (betav1 and v1) but it will always throw an exception (in 1.21) on one of them cause the version is removed from this kubernetes version.
I'm not completly happy with my solution but it works for me so far :)